### PR TITLE
Add Reactifpux slack group to react community

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ A collection of awesome React tools, resources, videos and shiny things.
 * [React #reactjs Twitter](https://twitter.com/search?q=%23reactjs)
 * [React SubReddit](http://www.reddit.com/r/reactjs/)
 * IRC network in `#reactjs` channel on freenode
+* [Reactiflux Slack Group](http://www.slackchats.com/site/contents/content/43043/2014-12-24/flux-reactjs-chat)
+
 
 #### Tutorials
 


### PR DESCRIPTION
There's a React + Flux group on Slack called Reactiflux: http://www.slackchats.com/site/contents/content/43043/2014-12-24/flux-reactjs-chat

It's pretty active everyday, and there's even a React core dev! This is great community, especially for people that already use Slack. 
